### PR TITLE
Allow the use of symbolic link

### DIFF
--- a/short_read_connector.sh
+++ b/short_read_connector.sh
@@ -4,7 +4,7 @@ version="1.0.0"
 
 
 
-EDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+EDIR=$( dirname "$( readlink -f "$0" 2> /dev/null || realpath "$0" )" )
 platform='mac'
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then

--- a/short_read_connector.sh
+++ b/short_read_connector.sh
@@ -4,7 +4,7 @@ version="1.0.0"
 
 
 
-EDIR=$( dirname "$( readlink -f "$0" 2> /dev/null || realpath "$0" )" )
+EDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )
 platform='mac'
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then


### PR DESCRIPTION
Fix the wrong resolution of EDIR when short_read_connector.sh is a symbolic link.
Works on linux and macos x